### PR TITLE
Attempted fix for localization issue

### DIFF
--- a/Localization/FRA/Instagib.FRA
+++ b/Localization/FRA/Instagib.FRA
@@ -1,2 +1,2 @@
-[ChatMessages]
+[Common]
 Welcome=Bienvenue à Instagib!

--- a/Localization/INT/Instagib.INT
+++ b/Localization/INT/Instagib.INT
@@ -1,4 +1,4 @@
-[Instagib]
+[Common]
 SpawnHeader=Instagib mod
 SpawnSubHeader=All hits, unless blocked, are instant kills.
 WelcomeChatText=You're playing Instagib mod. All hits, unless blocked, are instant kills. Respawn times are cut down. You can parry projectiles. Good luck!

--- a/include/InstagibPlayerController.uci
+++ b/include/InstagibPlayerController.uci
@@ -1,12 +1,14 @@
 reliable client function ClientOnFirstSpawn()
 {
-	//Localize() will find the "WelcomeChatText" key in the "Instagib" section of "Instagib.XXX" where XXX is replaced with the user's language's name (English is "INT")
-	//ReceiveChatMessage("",Localize("Instagib", "WelcomeChatText", "Instagib"),EFAC_ALL,false,false,,false);
+	//Localize() will find the "WelcomeChatText" key in the "Common" section of "Instagib.XXX" where XXX is replaced with the user's language's name (English is "INT")
+	//For whatever reason, the section of a localization file cannot be named after the name of your mod (e.g. "Instagib" as a section does not work in this case)
+	//ReceiveChatMessage("",Localize("Instagib", "WelcomeChatText", "Instagib"),EFAC_ALL,false,false,,false); <- Doesn't work!
+	ReceiveChatMessage("",Localize("Common", "WelcomeChatText", "Instagib"),EFAC_ALL,false,false,,false); // Should work
 	
 	//Only show this on first spawn. Afterwards, only the normal game mode header will show.
-	//ClientShowLocalizedHeaderText(Localize("Instagib","SpawnHeader","Instagib"),,Localize("Instagib","SpawnSubHeader","Instagib"),true,false);
+	ClientShowLocalizedHeaderText(Localize("Common","SpawnHeader","Instagib"),,Localize("Common","SpawnSubHeader","Instagib"),true,false);
 	
 	
-	ReceiveChatMessage("","You're playing Instagib mod. All hits, unless blocked, are instant kills. Respawn times are cut down. You can parry projectiles. Good luck!",EFAC_ALL,false,false,,false);
-	ClientShowLocalizedHeaderText("Instagib mod",,"All hits, unless blocked, are instant kills.",true,false);
+	//ReceiveChatMessage("","You're playing Instagib mod. All hits, unless blocked, are instant kills. Respawn times are cut down. You can parry projectiles. Good luck!",EFAC_ALL,false,false,,false);
+	//ClientShowLocalizedHeaderText("Instagib mod",,"All hits, unless blocked, are instant kills.",true,false);
 }


### PR DESCRIPTION
During the development of my own mod, I realized that localization only
functioned properly once I changed the section label of MODNAME.xxx from
"MODNAME" to "Common" (which I've done with this commit). I can only
assume that this is due to some internal naming conflict (but I can't
seem to find the source code for the Localize() method anywhere...)
